### PR TITLE
Add middleware to LOAD_PATH

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require "bundler/setup"
 
 $:.unshift(File.join(ccng_repo, "lib"))
 $:.unshift(File.join(ccng_repo, "app"))
+$:.unshift(File.join(ccng_repo, "middleware"))
 
 task :routes do
   Dir.chdir(ccng_repo) do


### PR DESCRIPTION
Fixes this error:

```
rake aborted!
LoadError: cannot load such file -- vcap_request_id
```
